### PR TITLE
getNetworkTypeName ignores JobInfo.NETWORK_TYPE_ANY

### DIFF
--- a/app/src/main/java/com/github/snuffix/jobschedulerdemoapp/MainActivity.java
+++ b/app/src/main/java/com/github/snuffix/jobschedulerdemoapp/MainActivity.java
@@ -184,7 +184,7 @@ public class MainActivity extends ActionBarActivity {
         } else if (networkType == JobInfo.NETWORK_TYPE_UNMETERED) {
             return getString(R.string.network_type_unmetered);
         } else {
-            return getString(R.string.network_type_none);
+            return getString(R.string.network_type_any);
         }
     }
 


### PR DESCRIPTION
getNetworkTypeName will return "NONE" when it should be "ANY"
